### PR TITLE
drop database before restore

### DIFF
--- a/cockroachdb/restore/cockroach-restore.sh
+++ b/cockroachdb/restore/cockroach-restore.sh
@@ -16,6 +16,6 @@ while read -r line
 do
   # pull db name from name of dump file. dump of db foobar is named foobar-dump.sql
   db=$(echo $line | sed 's|dumps/\(.*\)-dump.sql|\1|g')
-  cockroach sql --execute "CREATE DATABASE $db" --certs-dir=crts --host cockroachdb-cluster
+  cockroach sql --execute "DROP DATABASE $db; CREATE DATABASE $db" --certs-dir=crts --host cockroachdb-cluster
   cockroach sql --database $db --certs-dir=crts --host cockroachdb-cluster < $line
 done < <(ls dumps/*.sql)


### PR DESCRIPTION
restore from a dump was failing because DB and tables were already present so the sql dump script would fail after the first error. Drop the DB before doing the import to avoid any issues.