### PR TITLE
add versioning to dump file name

### DIFF
--- a/cockroachdb/backup/cockroach-backup.sh
+++ b/cockroachdb/backup/cockroach-backup.sh
@@ -23,8 +23,9 @@ do
 
 done < <(echo "show databases;" | cockroach sql --certs-dir=crts --host cockroachdb-cluster --format tsv)
 
+dump_name=dumps-$(date +%s).tar.gz
 # compress
-tar -czf dumps.tar.gz dumps
+tar -czf $dump_name dumps
 
 # send to s3
-s3cmd put -c /s3-config/s3cfg dumps.tar.gz s3://$S3_BUCKET/
+s3cmd put -c /s3-config/s3cfg $dump_name s3://$S3_BUCKET/

--- a/cockroachdb/backup/cockroach-backup.yaml
+++ b/cockroachdb/backup/cockroach-backup.yaml
@@ -4,7 +4,7 @@ metadata:
   namespace: default
   name: cockroach-backup
 spec:
-  schedule: "0 * * * *"
+  schedule: "0 */2 * * *"
   jobTemplate:
     spec:
       template:

--- a/cockroachdb/backup/lifecycle.xml
+++ b/cockroachdb/backup/lifecycle.xml
@@ -4,9 +4,9 @@
         <Filter>
            <Prefix></Prefix>
         </Filter>
-        <NoncurrentVersionExpiration>
-            <NoncurrentDays>1</NoncurrentDays>
-        </NoncurrentVersionExpiration>
+        <Expiration>
+            <Days>2</Days>
+        </Expiration>
         <Status>Enabled</Status>
     </Rule>
 </LifecycleConfiguration>


### PR DESCRIPTION
To avoid issues on scaleway where they cannot expire old versions.

The restore script already looks for the latest file and restores that so no changes needed there

Also tweak the backup frequency to every 2 hours instead of every hour