### PR TITLE
Example of a Prometheus client through our draft metrics interface

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,11 +7,13 @@ require (
 	github.com/google/uuid v1.1.1
 	github.com/micro/go-micro/v3 v3.0.0-alpha.0.20200812115214-1fa3ac5599eb
 	github.com/micro/micro/v3 v3.0.0-alpha.0.20200812122542-961cc414debf
+	github.com/prometheus/client_golang v1.7.0
 	github.com/sethvargo/go-diceware v0.2.0
 	github.com/slack-go/slack v0.6.5
 	github.com/stretchr/testify v1.5.1
 	github.com/stripe/stripe-go v70.15.0+incompatible
 	github.com/stripe/stripe-go/v71 v71.28.0
+	google.golang.org/protobuf v1.25.0
 )
 
 replace google.golang.org/grpc => google.golang.org/grpc v1.26.0

--- a/metrics/README.md
+++ b/metrics/README.md
@@ -1,0 +1,22 @@
+metrics
+=======
+
+The metrics package provides a simple metrics "Reporter" interface which allows the user to submit counters, gauges and timings (along with key/value tags).
+
+Implementations
+---------------
+
+* Prometheus (pull): will be first
+* Prometheus (push): certainly achievable
+* InfluxDB: could quite easily be done
+* Telegraf: almost identical to the InfluxDB implementation
+* Micro: Could we provide metrics over Micro's server interface?
+
+
+Todo
+----
+
+* Include a handler middleware which uses the Reporter interface to generate per-request level metrics
+    - Throughput
+    - Errors
+    - Duration

--- a/metrics/interface.go
+++ b/metrics/interface.go
@@ -1,0 +1,13 @@
+package metrics
+
+import "time"
+
+// Tags is a map of fields to add to a metric:
+type Tags map[string]string
+
+// Reporter is the standard metrics interface:
+type Reporter interface {
+	Count(metricName string, value int64, tags Tags) error
+	Gauge(metricName string, value float64, tags Tags) error
+	Timing(metricName string, value time.Duration, tags Tags) error
+}

--- a/metrics/prometheus/README.md
+++ b/metrics/prometheus/README.md
@@ -1,0 +1,33 @@
+Prometheus
+==========
+
+A Prometheus "pull" based implementation of the metrics Reporter interface.
+
+
+Capabilities
+------------
+
+* Go runtime metrics are handled natively by the Prometheus client library (CPU / MEM / GC / GoRoutines etc).
+* User-defined metrics are registered in the Prometheus client dynamically (they must be pre-registered, hence all of the faffing around in metric_family.go).
+* The metrics are made available on a Prometheus-compatible HTTP endpoint, which can be scraped at any time. This means that the user can very easily access stats even running locally as a standalone binary.
+* Requires a micro.Server parameter (from which it gathers the service name and version). These are included as tags with every metric.
+
+
+Usage
+-----
+
+```golang
+    prometheusReporter := metrics.New(server)
+    tags := metrics.Tags{"greeter": "Janos"}
+    err := prometheusReporter.Count("hellos", 1, tags)
+    if err != nil {
+        fmt.Printf("Error setting a Count metric: %v", err)
+    }
+```
+
+
+Todo
+----
+
+* Handle config parameters properly (rather than hardcoded vars)
+* Unit tests

--- a/metrics/prometheus/metric_family.go
+++ b/metrics/prometheus/metric_family.go
@@ -1,0 +1,107 @@
+package prometheus
+
+import (
+	"sync"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+// metricFamily stores our cached metrics:
+type metricFamily struct {
+	counters           map[string]*prometheus.CounterVec
+	gauges             map[string]*prometheus.GaugeVec
+	timings            map[string]*prometheus.SummaryVec
+	defaultLabels      prometheus.Labels
+	mutex              sync.Mutex
+	prometheusRegistry *prometheus.Registry
+}
+
+// newMetricFamily returns a new metricFamily (useful in case we want to change the structure later):
+func (r *Reporter) newMetricFamily() metricFamily {
+	return metricFamily{
+		counters:           make(map[string]*prometheus.CounterVec),
+		gauges:             make(map[string]*prometheus.GaugeVec),
+		timings:            make(map[string]*prometheus.SummaryVec),
+		defaultLabels:      r.defaultLabels,
+		prometheusRegistry: r.prometheusRegistry,
+	}
+}
+
+// getCounter either gets a counter, or makes a new one:
+func (mf *metricFamily) getCounter(name string, labelNames []string) *prometheus.CounterVec {
+	mf.mutex.Lock()
+	defer mf.mutex.Unlock()
+
+	// See if we already have this counter:
+	counter, ok := mf.counters[name]
+	if !ok {
+
+		// Make a new counter:
+		counter = prometheus.NewCounterVec(
+			prometheus.CounterOpts{
+				Name:        name,
+				ConstLabels: mf.defaultLabels,
+			},
+			labelNames,
+		)
+
+		// Register it and add it to our list:
+		mf.prometheusRegistry.MustRegister(counter)
+		mf.counters[name] = counter
+	}
+
+	return counter
+}
+
+// getGauge either gets a gauge, or makes a new one:
+func (mf *metricFamily) getGauge(name string, labelNames []string) *prometheus.GaugeVec {
+	mf.mutex.Lock()
+	defer mf.mutex.Unlock()
+
+	// See if we already have this gauge:
+	gauge, ok := mf.gauges[name]
+	if !ok {
+
+		// Make a new gauge:
+		gauge = prometheus.NewGaugeVec(
+			prometheus.GaugeOpts{
+				Name:        name,
+				ConstLabels: mf.defaultLabels,
+			},
+			labelNames,
+		)
+
+		// Register it and add it to our list:
+		mf.prometheusRegistry.MustRegister(gauge)
+		mf.gauges[name] = gauge
+	}
+
+	return gauge
+}
+
+// getTiming either gets a timing, or makes a new one:
+func (mf *metricFamily) getTiming(name string, labelNames []string) *prometheus.SummaryVec {
+	mf.mutex.Lock()
+	defer mf.mutex.Unlock()
+
+	// See if we already have this timing:
+	timing, ok := mf.timings[name]
+	if !ok {
+
+		// Make a new timing:
+		timing = prometheus.NewSummaryVec(
+			prometheus.SummaryOpts{
+				Name:        name,
+				ConstLabels: mf.defaultLabels,
+				Objectives:  timingObjectives,
+			},
+			labelNames,
+		)
+
+		// Register it and add it to our list:
+		mf.prometheusRegistry.MustRegister(timing)
+		mf.timings[name] = timing
+	}
+
+	return timing
+}

--- a/metrics/prometheus/metrics.go
+++ b/metrics/prometheus/metrics.go
@@ -1,0 +1,68 @@
+package prometheus
+
+import (
+	"errors"
+	"time"
+
+	"github.com/m3o/services/metrics"
+)
+
+// ErrPrometheusPanic is a catch-all for the panics which can be thrown by the Prometheus client:
+var ErrPrometheusPanic = errors.New("The Prometheus client panicked. Did you do something like change the tag cardinality or the type of a metric?")
+
+// Count is a counter with key/value tags:
+// New values are added to any previous one (eg "number of hits")
+func (r *Reporter) Count(name string, value int64, tags metrics.Tags) (err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			err = ErrPrometheusPanic
+		}
+	}()
+
+	counter := r.metrics.getCounter(r.stripUnsupportedCharacters(name), r.listTagKeys(tags))
+	metric, err := counter.GetMetricWith(r.convertTags(tags))
+	if err != nil {
+		return err
+	}
+
+	metric.Add(float64(value))
+	return err
+}
+
+// Gauge is a register with key/value tags:
+// New values simply override any previous one (eg "current connections")
+func (r *Reporter) Gauge(name string, value float64, tags metrics.Tags) (err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			err = ErrPrometheusPanic
+		}
+	}()
+
+	gauge := r.metrics.getGauge(r.stripUnsupportedCharacters(name), r.listTagKeys(tags))
+	metric, err := gauge.GetMetricWith(r.convertTags(tags))
+	if err != nil {
+		return err
+	}
+
+	metric.Set(value)
+	return err
+}
+
+// Timing is a histogram with key/valye tags:
+// New values are added into a series of aggregations
+func (r *Reporter) Timing(name string, value time.Duration, tags metrics.Tags) (err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			err = ErrPrometheusPanic
+		}
+	}()
+
+	timing := r.metrics.getTiming(r.stripUnsupportedCharacters(name), r.listTagKeys(tags))
+	metric, err := timing.GetMetricWith(r.convertTags(tags))
+	if err != nil {
+		return err
+	}
+
+	metric.Observe(value.Seconds())
+	return err
+}

--- a/metrics/prometheus/reporter.go
+++ b/metrics/prometheus/reporter.go
@@ -1,0 +1,86 @@
+package prometheus
+
+import (
+	"net/http"
+	"strings"
+
+	"github.com/m3o/services/metrics"
+	log "github.com/micro/go-micro/v3/logger"
+	"github.com/micro/micro/v3/service"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+)
+
+// TODO: These sensible defaults should really become config options
+var (
+	// The Prometheus metrics will be made available on this port:
+	listenAddress = ":9000"
+	// This is the endpoint where the Prometheus metrics will be made available ("/metrics" is the default with Prometheus):
+	metricsEndpoint = "/metrics"
+	// timingObjectives is the default spread of stats we maintain for timings / histograms:
+	timingObjectives = map[float64]float64{0.0: 0, 0.5: 0.05, 0.75: 0.04, 0.90: 0.03, 0.95: 0.02, 0.98: 0.001, 1: 0}
+)
+
+// Reporter is an implementation of metrics.Reporter:
+type Reporter struct {
+	defaultLabels      prometheus.Labels
+	prometheusRegistry *prometheus.Registry
+	metrics            metricFamily
+}
+
+// New returns a configured prometheus reporter:
+func New(service *service.Service) (*Reporter, error) {
+
+	// Make a prometheus registry (this keeps track of any metrics we generate):
+	prometheusRegistry := prometheus.NewRegistry()
+	prometheusRegistry.Register(prometheus.NewGoCollector())
+	prometheusRegistry.Register(prometheus.NewProcessCollector(prometheus.ProcessCollectorOpts{Namespace: "goruntime"}))
+
+	// Make a new Reporter:
+	newReporter := &Reporter{
+		prometheusRegistry: prometheusRegistry,
+	}
+
+	// Prepare some default tags which will be included with every metric (based on the service metadata):
+	if service != nil {
+		newReporter.defaultLabels = prometheus.Labels{
+			"service_name":    service.Name(),
+			"service_version": service.Version(),
+		}
+	}
+
+	// Add metrics families for each type:
+	newReporter.metrics = newReporter.newMetricFamily()
+
+	// Handle the metrics endpoint with prometheus:
+	log.Infof("Metrics/Prometheus [http] Listening on %s%s", listenAddress, metricsEndpoint)
+	http.Handle(metricsEndpoint, promhttp.HandlerFor(prometheusRegistry, promhttp.HandlerOpts{ErrorHandling: promhttp.ContinueOnError}))
+	go http.ListenAndServe(listenAddress, nil)
+
+	return newReporter, nil
+}
+
+// convertTags turns Tags into prometheus labels:
+func (r *Reporter) convertTags(tags metrics.Tags) prometheus.Labels {
+	labels := prometheus.Labels{}
+	for key, value := range tags {
+		labels[key] = r.stripUnsupportedCharacters(value)
+	}
+	return labels
+}
+
+// listTagKeys returns a list of tag keys (we need to provide this to the Prometheus client):
+func (r *Reporter) listTagKeys(tags metrics.Tags) (labelKeys []string) {
+	for key := range tags {
+		labelKeys = append(labelKeys, key)
+	}
+	return
+}
+
+// stripUnsupportedCharacters cleans up a metrics key or value:
+func (r *Reporter) stripUnsupportedCharacters(metricName string) string {
+	valueWithoutDots := strings.Replace(metricName, ".", "_", -1)
+	valueWithoutCommas := strings.Replace(valueWithoutDots, ",", "_", -1)
+	valueWIthoutSpaces := strings.Replace(valueWithoutCommas, " ", "", -1)
+	return valueWIthoutSpaces
+}

--- a/metrics/prometheus/reporter_test.go
+++ b/metrics/prometheus/reporter_test.go
@@ -1,0 +1,74 @@
+package prometheus
+
+import (
+	"testing"
+	"time"
+
+	"github.com/m3o/services/metrics"
+	"github.com/micro/micro/v3/service"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPrometheusReporter(t *testing.T) {
+
+	// New Service:
+	srv := service.New(
+		service.Name("test-metrics"),
+		service.Version("1.2.3"),
+	)
+
+	// Make a Reporter:
+	reporter, err := New(srv)
+	assert.NoError(t, err)
+	assert.NotNil(t, reporter)
+
+	// Test tag conversion:
+	tags := metrics.Tags{
+		"tag1": "false",
+		"tag2": "true",
+	}
+	convertedTags := reporter.convertTags(tags)
+	assert.Equal(t, "false", convertedTags["tag1"])
+	assert.Equal(t, "true", convertedTags["tag2"])
+
+	// Test tag enumeration:
+	listedTags := reporter.listTagKeys(tags)
+	assert.Contains(t, listedTags, "tag1")
+	assert.Contains(t, listedTags, "tag2")
+
+	// Test string cleaning:
+	preparedMetricName := reporter.stripUnsupportedCharacters("some.kind,of tag")
+	assert.Equal(t, "some_kind_oftag", preparedMetricName)
+
+	// Test MetricFamilies:
+	metricFamily := reporter.newMetricFamily()
+
+	// Counters:
+	assert.NotNil(t, metricFamily.getCounter("testCounter", []string{"test", "counter"}))
+	assert.Len(t, metricFamily.counters, 1)
+
+	// Gauges:
+	assert.NotNil(t, metricFamily.getGauge("testGauge", []string{"test", "gauge"}))
+	assert.Len(t, metricFamily.gauges, 1)
+
+	// Timings:
+	assert.NotNil(t, metricFamily.getTiming("testTiming", []string{"test", "timing"}))
+	assert.Len(t, metricFamily.timings, 1)
+
+	// Test submitting metrics through the interface methods:
+	assert.NoError(t, reporter.Count("test.counter.1", 6, tags))
+	assert.NoError(t, reporter.Count("test.counter.2", 19, tags))
+	assert.NoError(t, reporter.Count("test.counter.1", 5, tags))
+	assert.NoError(t, reporter.Gauge("test.gauge.1", 99, tags))
+	assert.NoError(t, reporter.Gauge("test.gauge.2", 55, tags))
+	assert.NoError(t, reporter.Gauge("test.gauge.1", 98, tags))
+	assert.NoError(t, reporter.Timing("test.timing.1", time.Second, tags))
+	assert.NoError(t, reporter.Timing("test.timing.2", time.Minute, tags))
+	assert.Len(t, reporter.metrics.counters, 2)
+	assert.Len(t, reporter.metrics.gauges, 2)
+	assert.Len(t, reporter.metrics.timings, 2)
+
+	// Test reading back the metrics:
+	// This could be done by hitting the /metrics endpoint
+}

--- a/metrics/wrapper/metrics_wrapper.go
+++ b/metrics/wrapper/metrics_wrapper.go
@@ -1,0 +1,51 @@
+package wrapper
+
+import (
+	"time"
+
+	"context"
+
+	"github.com/m3o/services/metrics"
+	"github.com/micro/go-micro/v3/server"
+)
+
+// Wrapper provides a HandlerFunc for metrics.Reporter implementations:
+type Wrapper struct {
+	reporter metrics.Reporter
+}
+
+// New returns a *Wrapper configured with the given metrics.Reporter:
+func New(reporter metrics.Reporter) *Wrapper {
+	return &Wrapper{
+		reporter: reporter,
+	}
+}
+
+// HandlerFunc instruments handlers registered to a service:
+func (w *Wrapper) HandlerFunc(handlerFunction server.HandlerFunc) server.HandlerFunc {
+	return func(ctx context.Context, req server.Request, rsp interface{}) error {
+
+		// Build some tags to describe the call:
+		tags := metrics.Tags{
+			"method": req.Method(),
+		}
+
+		// Start the clock:
+		callTime := time.Now()
+
+		// Run the handlerFunction:
+		err := handlerFunction(ctx, req, rsp)
+
+		// Add a result tag:
+		if err != nil {
+			tags["result"] = "failure"
+		} else {
+			tags["result"] = "failure"
+		}
+
+		// Instrument the result (if the DefaultClient has been configured):
+		w.reporter.Timing("service.handler", time.Since(callTime), tags)
+
+		return err
+	}
+}

--- a/status/main.go
+++ b/status/main.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"github.com/m3o/services/metrics/prometheus"
+	"github.com/m3o/services/metrics/wrapper"
 	"github.com/m3o/services/status/handler"
 	log "github.com/micro/go-micro/v3/logger"
 	"github.com/micro/micro/v3/service"
@@ -8,10 +10,24 @@ import (
 )
 
 func main() {
+
+	// Make a metrics.Reporter (should take a *service.Service but that is circular until we can embed metrics into the service code):
+	reporter, err := prometheus.New(nil)
+	if err != nil {
+		log.Errorf("Error starting Prometheus metrics reporter")
+	}
+
+	metricsWrapper := wrapper.New(reporter)
+
 	// New Service
 	srv := service.New(
 		service.Name("status"),
+		service.Version("0.0.1"),
+		service.WrapHandler(metricsWrapper.HandlerFunc),
 	)
+
+	// An example metric:
+	reporter.Count("service_start", 1, nil)
 
 	// grab services to monitor
 	svcs := config.Get("micro", "status", "services").StringSlice(nil)


### PR DESCRIPTION
Note: I've included the prometheus metrics implementation in this PR even though it should actually live in `micro/go-micro/metrics/prometheus`, because until that PR is merged it is a bit of a hassle with dependencies.

Some thoughts so far:

- Eventually I have visions of the metrics reporter being built into service.Service, enabled by config options. Maybe until we're happy with this let's just do it the hard way in main.go for our own core Micro platform services.
- Currently the Prometheus reporter just blindly listens on port TCP/9000. This should be a reasonable default for running inside Kubernetes, but if a user were to try to run more than one service locally the ports would clash. Perhaps when `--profile=local` it should pick a random port.
- Adding a `service.WrapHandler()` option is a bit circular unless we take care of metrics within the service.Service (metrics needs a service instance to get the name and version from, but the service object needs a metrics instance to provide the handler). For now I've allowed it to take a `nil` here and carry on without service-specific tags.