### PR TITLE
fix restore script

### DIFF
--- a/database/restore/cockroach-restore.sh
+++ b/database/restore/cockroach-restore.sh
@@ -16,6 +16,6 @@ while read -r line
 do
   # pull db name from name of dump file. dump of db foobar is named foobar-dump.sql
   db=$(echo $line | sed 's|dumps/\(.*\)-dump.sql|\1|g')
-  cockroach sql --execute "DROP DATABASE $db; CREATE DATABASE $db" --certs-dir=crts --host cockroachdb-cluster
+  cockroach sql --execute "DROP DATABASE IF EXISTS $db; CREATE DATABASE $db" --certs-dir=crts --host cockroachdb-cluster
   cockroach sql --database $db --certs-dir=crts --host cockroachdb-cluster < $line
 done < <(ls dumps/*.sql)


### PR DESCRIPTION
Drop database only if exists. 

This is what caused the restore to fail post outage