### PR TITLE
Idempotent subscription cancel

### DIFF
--- a/customers/handler/customer.go
+++ b/customers/handler/customer.go
@@ -251,7 +251,7 @@ func (c *Customers) deleteCustomer(ctx context.Context, customerID string) error
 			Id:      customerID,
 			Options: &aproto.Options{Namespace: ns.Id},
 		}, client.WithAuthToken())
-		if err != nil {
+		if ignoreError(err) != nil {
 			return err
 		}
 		// are we the owner
@@ -263,7 +263,7 @@ func (c *Customers) deleteCustomer(ctx context.Context, customerID string) error
 	// delete any owned namespaces
 	for _, ns := range owned {
 		_, err := c.namespacesService.Delete(ctx, &nsproto.DeleteRequest{Id: ns}, client.WithAuthToken())
-		if err != nil {
+		if ignoreError(err) != nil {
 			return err
 		}
 	}
@@ -277,6 +277,20 @@ func (c *Customers) deleteCustomer(ctx context.Context, customerID string) error
 	ev := CustomerEvent{Customer: *cust, Type: "customers.deleted"}
 	if err := mevents.Publish(custTopic, ev); err != nil {
 		log.Errorf("Error publishing customers.deleted event %+v", ev)
+	}
+	return nil
+}
+
+// ignoreError will ignore any 400 or 404 errors returned, useful for idempotent deletes
+func ignoreError(err error) error {
+	if err != nil {
+		merr, ok := err.(*errors.Error)
+		if !ok {
+			return err
+		}
+		if merr.Code != 400 && merr.Code != 404 {
+			return err
+		}
 	}
 	return nil
 }

--- a/customers/handler/customer.go
+++ b/customers/handler/customer.go
@@ -251,7 +251,7 @@ func (c *Customers) deleteCustomer(ctx context.Context, customerID string) error
 			Id:      customerID,
 			Options: &aproto.Options{Namespace: ns.Id},
 		}, client.WithAuthToken())
-		if ignoreError(err) != nil {
+		if ignoreDeleteError(err) != nil {
 			return err
 		}
 		// are we the owner
@@ -263,7 +263,7 @@ func (c *Customers) deleteCustomer(ctx context.Context, customerID string) error
 	// delete any owned namespaces
 	for _, ns := range owned {
 		_, err := c.namespacesService.Delete(ctx, &nsproto.DeleteRequest{Id: ns}, client.WithAuthToken())
-		if ignoreError(err) != nil {
+		if ignoreDeleteError(err) != nil {
 			return err
 		}
 	}
@@ -281,8 +281,8 @@ func (c *Customers) deleteCustomer(ctx context.Context, customerID string) error
 	return nil
 }
 
-// ignoreError will ignore any 400 or 404 errors returned, useful for idempotent deletes
-func ignoreError(err error) error {
+// ignoreDeleteError will ignore any 400 or 404 errors returned, useful for idempotent deletes
+func ignoreDeleteError(err error) error {
 	if err != nil {
 		merr, ok := err.(*errors.Error)
 		if !ok {

--- a/customers/handler/customer.go
+++ b/customers/handler/customer.go
@@ -288,9 +288,10 @@ func ignoreError(err error) error {
 		if !ok {
 			return err
 		}
-		if merr.Code != 400 && merr.Code != 404 {
-			return err
+		if merr.Code == 400 || merr.Code == 404 {
+			return nil
 		}
+		return err
 	}
 	return nil
 }

--- a/namespaces/handler/namespace.go
+++ b/namespaces/handler/namespace.go
@@ -194,7 +194,7 @@ func (n Namespaces) Delete(ctx context.Context, request *namespace.DeleteRequest
 	}
 
 	_, err = n.platformService.DeleteNamespace(ctx, &plproto.DeleteNamespaceRequest{Name: request.Id}, client.WithAuthToken())
-	if err != nil {
+	if ignoreError(err) != nil {
 		return err
 	}
 	// delete any stray accounts
@@ -209,23 +209,25 @@ func (n Namespaces) Delete(ctx context.Context, request *namespace.DeleteRequest
 				Id:      acc.Id,
 				Options: &aproto.Options{Namespace: acc.Issuer},
 			})
-		if err != nil {
+		if ignoreError(err) != nil {
 			return err
 		}
 	}
 
 	// delete any stray auth rules
 	rrsp, err := n.rulesService.List(ctx, &aproto.ListRequest{Options: &aproto.Options{Namespace: ns.ID}})
-	if err != nil {
+	if ignoreError(err) != nil {
 		return err
 	}
-	for _, rule := range rrsp.Rules {
-		_, err := n.rulesService.Delete(ctx, &aproto.DeleteRequest{
-			Id:      rule.Id,
-			Options: &aproto.Options{Namespace: ns.ID},
-		})
-		if err != nil {
-			return err
+	if rrsp != nil {
+		for _, rule := range rrsp.Rules {
+			_, err := n.rulesService.Delete(ctx, &aproto.DeleteRequest{
+				Id:      rule.Id,
+				Options: &aproto.Options{Namespace: ns.ID},
+			})
+			if ignoreError(err) != nil {
+				return err
+			}
 		}
 	}
 
@@ -277,6 +279,24 @@ func (n Namespaces) List(ctx context.Context, request *namespace.ListRequest, re
 		res = append(res, objToProto(ns))
 	}
 	response.Namespaces = res
+	return nil
+}
+
+// ignoreError will ignore any 400 or 404 errors returned, useful for idempotent deletes
+func ignoreError(err error) error {
+	if err != nil {
+		merr, ok := err.(*errors.Error)
+		if !ok {
+			return err
+		}
+		if strings.Contains(merr.Detail, "not found") {
+			return nil
+		}
+		if merr.Code == 400 || merr.Code == 404 {
+			return nil
+		}
+		return err
+	}
 	return nil
 }
 

--- a/namespaces/handler/namespace.go
+++ b/namespaces/handler/namespace.go
@@ -194,7 +194,7 @@ func (n Namespaces) Delete(ctx context.Context, request *namespace.DeleteRequest
 	}
 
 	_, err = n.platformService.DeleteNamespace(ctx, &plproto.DeleteNamespaceRequest{Name: request.Id}, client.WithAuthToken())
-	if ignoreError(err) != nil {
+	if ignoreDeleteError(err) != nil {
 		return err
 	}
 	// delete any stray accounts
@@ -209,14 +209,14 @@ func (n Namespaces) Delete(ctx context.Context, request *namespace.DeleteRequest
 				Id:      acc.Id,
 				Options: &aproto.Options{Namespace: acc.Issuer},
 			})
-		if ignoreError(err) != nil {
+		if ignoreDeleteError(err) != nil {
 			return err
 		}
 	}
 
 	// delete any stray auth rules
 	rrsp, err := n.rulesService.List(ctx, &aproto.ListRequest{Options: &aproto.Options{Namespace: ns.ID}})
-	if ignoreError(err) != nil {
+	if ignoreDeleteError(err) != nil {
 		return err
 	}
 	if rrsp != nil {
@@ -225,7 +225,7 @@ func (n Namespaces) Delete(ctx context.Context, request *namespace.DeleteRequest
 				Id:      rule.Id,
 				Options: &aproto.Options{Namespace: ns.ID},
 			})
-			if ignoreError(err) != nil {
+			if ignoreDeleteError(err) != nil {
 				return err
 			}
 		}
@@ -282,8 +282,8 @@ func (n Namespaces) List(ctx context.Context, request *namespace.ListRequest, re
 	return nil
 }
 
-// ignoreError will ignore any 400 or 404 errors returned, useful for idempotent deletes
-func ignoreError(err error) error {
+// ignoreDeleteError will ignore any 400 or 404 errors returned, useful for idempotent deletes
+func ignoreDeleteError(err error) error {
 	if err != nil {
 		merr, ok := err.(*errors.Error)
 		if !ok {


### PR DESCRIPTION
Make subscription cancel (customer and namespace delete) idempotent or at least more tolerant to errors