### PR TITLE
Alert service fixes

### DIFF
--- a/.github/workflows/integration-m3o.yml
+++ b/.github/workflows/integration-m3o.yml
@@ -54,7 +54,7 @@ jobs:
           # Generate keys for JWT tests
           ssh-keygen -f /tmp/sshkey -m pkcs8 -q -N ""
           ssh-keygen -f /tmp/sshkey -e  -m pkcs8 > /tmp/sshkey.pub
-          go clean -testcache && go test -timeout 15m --tags=m3o -v ./...
+          go clean -testcache && GOMAXPROCS=4 go test -timeout 15m --tags=m3o -v ./...
       env:
         MICRO_STRIPE_API_KEY: ${{ secrets.MICRO_STRIPE_API_KEY }}
         MICRO_SENDGRID_API_KEY: ${{ secrets.MICRO_SENDGRID_API_KEY }}

--- a/.github/workflows/integration-m3o.yml
+++ b/.github/workflows/integration-m3o.yml
@@ -54,7 +54,7 @@ jobs:
           # Generate keys for JWT tests
           ssh-keygen -f /tmp/sshkey -m pkcs8 -q -N ""
           ssh-keygen -f /tmp/sshkey -e  -m pkcs8 > /tmp/sshkey.pub
-          go clean -testcache && GOMAXPROCS=4 go test -timeout 15m --tags=m3o -v ./...
+          go clean -testcache && go test -timeout 15m --tags=m3o -v ./...
       env:
         MICRO_STRIPE_API_KEY: ${{ secrets.MICRO_STRIPE_API_KEY }}
         MICRO_SENDGRID_API_KEY: ${{ secrets.MICRO_SENDGRID_API_KEY }}

--- a/alert/handler/alert.go
+++ b/alert/handler/alert.go
@@ -107,7 +107,6 @@ func (e *Alert) ReportEvent(ctx context.Context, req *alert.ReportEventRequest, 
 			return err
 		}
 		msg := fmt.Sprintf("Event received:\n```\n%v\n```", string(jsond))
-		// TODO make this channel configurable
 		_, _, _, err = e.slackClient.SendMessage(e.config.Slack.Channel, slack.MsgOptionUsername(e.config.Slack.Username), slack.MsgOptionText(msg, false))
 		if err != nil {
 			return err

--- a/alert/handler/alert.go
+++ b/alert/handler/alert.go
@@ -95,7 +95,8 @@ func (e *Alert) ReportEvent(ctx context.Context, req *alert.ReportEventRequest, 
 			return err
 		}
 		msg := fmt.Sprintf("Event received:\n```\n%v\n```", string(jsond))
-		_, _, _, err = e.slackClient.SendMessage("errors", slack.MsgOptionUsername("Alert Service"), slack.MsgOptionText(msg, false))
+		// TODO make this channel configurable
+		_, _, _, err = e.slackClient.SendMessage("alerts", slack.MsgOptionUsername("Alert Service"), slack.MsgOptionText(msg, false))
 		if err != nil {
 			return err
 		}

--- a/alert/handler/alert.go
+++ b/alert/handler/alert.go
@@ -36,11 +36,16 @@ type event struct {
 	Metadata map[string]string `json:"metadata"`
 }
 
+type slackConf struct {
+	Token    string `json:"token"`
+	Enabled  bool   `json:"enabled"`
+	Channel  string `json:"channel"`
+	Username string `json:"user_name"`
+}
+
 type conf struct {
-	SlackToken   string `json:"slack_token"`
-	SlackEnabled bool   `json:"slack_enabled"`
-	SlackChannel string `json:"slack_channel"`
-	GaPropertyID string `json:"ga_property_id"`
+	Slack        slackConf `json:"slack"`
+	GaPropertyID string    `json:"ga_property_id"`
 }
 
 func NewAlert() *Alert {
@@ -53,19 +58,22 @@ func NewAlert() *Alert {
 	if err != nil {
 		log.Warnf("Error scanning config: %v", err)
 	}
-	if c.SlackEnabled && len(c.SlackToken) == 0 {
+	if c.Slack.Enabled && len(c.Slack.Token) == 0 {
 		log.Errorf("Slack token missing")
 	}
 	if len(c.GaPropertyID) == 0 {
 		log.Errorf("Google Analytics key (property ID) is missing")
 	}
-	log.Infof("Slack enabled: %v", c.SlackEnabled)
-	if len(c.SlackChannel) == 0 {
-		c.SlackChannel = "alerts"
+	log.Infof("Slack enabled: %v", c.Slack.Enabled)
+	if len(c.Slack.Channel) == 0 {
+		c.Slack.Channel = "alerts"
+	}
+	if len(c.Slack.Username) == 0 {
+		c.Slack.Username = "Alert Service"
 	}
 
 	return &Alert{
-		slackClient: slack.New(c.SlackToken),
+		slackClient: slack.New(c.Slack.Token),
 		config:      c,
 	}
 }
@@ -93,14 +101,14 @@ func (e *Alert) ReportEvent(ctx context.Context, req *alert.ReportEventRequest, 
 	if err != nil {
 		log.Warnf("Error sending event to google analytics: %v", err)
 	}
-	if e.config.SlackEnabled && req.Event.Action != "success" { // don't care about success actions right now
+	if e.config.Slack.Enabled && req.Event.Action != "success" { // don't care about success actions right now
 		jsond, err := json.MarshalIndent(req.Event, "", "   ")
 		if err != nil {
 			return err
 		}
 		msg := fmt.Sprintf("Event received:\n```\n%v\n```", string(jsond))
 		// TODO make this channel configurable
-		_, _, _, err = e.slackClient.SendMessage(e.config.SlackChannel, slack.MsgOptionUsername("Alert Service"), slack.MsgOptionText(msg, false))
+		_, _, _, err = e.slackClient.SendMessage(e.config.Slack.Channel, slack.MsgOptionUsername(e.config.Slack.Username), slack.MsgOptionText(msg, false))
 		if err != nil {
 			return err
 		}

--- a/tests/integration/signup/signup_test.go
+++ b/tests/integration/signup/signup_test.go
@@ -196,7 +196,7 @@ func logout(serv test.Server, t *test.T) {
 }
 
 func testSignupFlow(t *test.T) {
-	//t.Parallel()
+	t.Parallel()
 
 	serv := test.NewServer(t, test.WithLogin())
 	defer serv.Close()
@@ -1290,7 +1290,7 @@ func TestFreeSignupFlow(t *testing.T) {
 }
 
 func testFreeSignupFlow(t *test.T) {
-	//t.Parallel()
+	t.Parallel()
 
 	serv := test.NewServer(t, test.WithLogin())
 	defer serv.Close()

--- a/tests/integration/signup/signup_test.go
+++ b/tests/integration/signup/signup_test.go
@@ -648,7 +648,7 @@ func testServicesSubscription(t *test.T) {
 	serv.Command().Exec("run", "github.com/micro/services/helloworld")
 	serv.Command().Exec("run", "github.com/micro/services/blog/posts")
 	serv.Command().Exec("run", "github.com/micro/services/blog/tags")
-	serv.Command().Exec("run", "github.com/micro/services/pubsub")
+	serv.Command().Exec("run", "github.com/micro/services/test/pubsub")
 
 	test.Try("Wait for services", t, func() ([]byte, error) {
 		outp, err := serv.Command().Exec("status")

--- a/tests/integration/signup/signup_test.go
+++ b/tests/integration/signup/signup_test.go
@@ -196,7 +196,7 @@ func logout(serv test.Server, t *test.T) {
 }
 
 func testSignupFlow(t *test.T) {
-	t.Parallel()
+	//t.Parallel()
 
 	serv := test.NewServer(t, test.WithLogin())
 	defer serv.Close()
@@ -1290,7 +1290,7 @@ func TestFreeSignupFlow(t *testing.T) {
 }
 
 func testFreeSignupFlow(t *test.T) {
-	t.Parallel()
+	//t.Parallel()
 
 	serv := test.NewServer(t, test.WithLogin())
 	defer serv.Close()


### PR DESCRIPTION
Make slack channel configurable.
Ignore events with `action=success` for pushing to Slack.
Make slack username configurable.