### PR TITLE
Quota fixes

### DIFF
--- a/platform/handler/platform.go
+++ b/platform/handler/platform.go
@@ -27,29 +27,23 @@ type Platform struct {
 // New returns an initialised platform handler
 func New(service *service.Service) *Platform {
 
-	if val, err := config.Get("micro.platform.resource_limits.cpu"); err != nil {
-		defaultResourceLimits.CPU = int32(val.Int(8000))
-	}
+	val, _ := config.Get("micro.platform.resource_limits.cpu")
+	defaultResourceLimits.CPU = int32(val.Int(8000))
 
-	if val, err := config.Get("micro.platform.resource_limits.disk"); err != nil {
-		defaultResourceLimits.EphemeralStorage = int32(val.Int(8000))
-	}
+	val, _ = config.Get("micro.platform.resource_limits.disk")
+	defaultResourceLimits.EphemeralStorage = int32(val.Int(8000))
 
-	if val, err := config.Get("micro.platform.resource_limits.memory"); err != nil {
-		defaultResourceLimits.Memory = int32(val.Int(8000))
-	}
+	val, _ = config.Get("micro.platform.resource_limits.memory")
+	defaultResourceLimits.Memory = int32(val.Int(8000))
 
-	if val, err := config.Get("micro.platform.resource_requests.cpu"); err != nil {
-		defaultResourceRequests.CPU = int32(val.Int(8000))
-	}
+	val, _ = config.Get("micro.platform.resource_requests.cpu")
+	defaultResourceRequests.CPU = int32(val.Int(8000))
 
-	if val, err := config.Get("micro.platform.resource_requests.disk"); err != nil {
-		defaultResourceRequests.EphemeralStorage = int32(val.Int(8000))
-	}
+	val, _ = config.Get("micro.platform.resource_requests.disk")
+	defaultResourceRequests.EphemeralStorage = int32(val.Int(8000))
 
-	if val, err := config.Get("micro.platform.resource_requests.memory"); err != nil {
-		defaultResourceRequests.Memory = int32(val.Int(8000))
-	}
+	val, _ = config.Get("micro.platform.resource_requests.memory")
+	defaultResourceRequests.Memory = int32(val.Int(8000))
 
 	return &Platform{
 		name:    service.Name(),

--- a/tests/integration/signup/signup_test.go
+++ b/tests/integration/signup/signup_test.go
@@ -341,7 +341,7 @@ func testInviteScenarios(t *test.T) {
 	if testDuplicateInvites(t, serv); t.Failed() {
 		return
 	}
-	testInviteEmailValidation(t, serv); t.Failed() {
+	if testInviteEmailValidation(t, serv); t.Failed() {
 		return
 	}
 

--- a/tests/integration/signup/signup_test.go
+++ b/tests/integration/signup/signup_test.go
@@ -326,7 +326,9 @@ func testInviteScenarios(t *test.T) {
 		return
 	}
 
-	setupM3Tests(serv, t)
+	if setupM3Tests(serv, t); t.Failed() {
+		return
+	}
 
 	emails := []string{}
 	// Make sure test mod is on otherwise this will spam
@@ -336,14 +338,26 @@ func testInviteScenarios(t *test.T) {
 			return serv.Command().Exec("invite", "user", "--email="+emails[i])
 		}, 5*time.Second)
 	}
-	testDuplicateInvites(t, serv)
-	testInviteEmailValidation(t, serv)
+	if testDuplicateInvites(t, serv); t.Failed() {
+		return
+	}
+	testInviteEmailValidation(t, serv); t.Failed() {
+		return
+	}
 
 	logout(serv, t)
-	testUserInviteLimit(t, serv, emails[0])
-	testUserInviteNoJoin(t, serv, emails[1])
-	testUserInviteJoinDecline(t, serv, emails[2])
-	testUserInviteToNotOwnedNamespace(t, serv, emails[3])
+	if testUserInviteLimit(t, serv, emails[0]); t.Failed() {
+		return
+	}
+	if testUserInviteNoJoin(t, serv, emails[1]); t.Failed() {
+		return
+	}
+	if testUserInviteJoinDecline(t, serv, emails[2]); t.Failed() {
+		return
+	}
+	if testUserInviteToNotOwnedNamespace(t, serv, emails[3]); t.Failed() {
+		return
+	}
 
 }
 

--- a/tests/integration/signup/signup_test.go
+++ b/tests/integration/signup/signup_test.go
@@ -129,6 +129,7 @@ func setupM3TestsImpl(serv test.Server, t *test.T, freeTier bool) {
 			t.Fatal(string(outp))
 			return
 		}
+		time.Sleep(2 * time.Second)
 	}
 	runLock.Unlock()
 


### PR DESCRIPTION
Fix config parsing for quotas, value was only being set if error.

TODO we don't currently set limits or requests on deployments so we get this error currently when trying to run a service in a namespace with quotas switched on

```
$ k get events -n moneybags-earthworm-evaluate 
LAST SEEN   TYPE      REASON              OBJECT                                    MESSAGE
9m44s       Warning   FailedCreate        replicaset/helloworld-latest-6b78556b99   Error creating: pods "helloworld-latest-6b78556b99-mcpwh" is forbidden: failed quota: quota: must specify limits.cpu,limits.memory,requests.cpu,requests.memory
9m44s       Warning   FailedCreate        replicaset/helloworld-latest-6b78556b99   Error creating: pods "helloworld-latest-6b78556b99-xng7m" is forbidden: failed quota: quota: must specify limits.cpu,limits.memory,requests.cpu,requests.memory
9m44s       Warning   FailedCreate        replicaset/helloworld-latest-6b78556b99   Error creating: pods "helloworld-latest-6b78556b99-88q7g" is forbidden: failed quota: quota: must specify limits.cpu,limits.memory,requests.cpu,requests.memory
```

This is explained here https://kubernetes.io/docs/concepts/policy/resource-quotas/ 

> If quota is enabled in a namespace for compute resources like cpu and memory, users must specify requests or limits for those values; otherwise, the quota system may reject pod creation. Hint: Use the LimitRanger admission controller to force defaults for pods that make no compute resource requirements.


We can either add a quick fix to deployments to set some defaults on deployments or add a [limit range](https://kubernetes.io/docs/concepts/policy/limit-range/) to be created on every namespace. 

cc @chrusty @asim 