### PR TITLE
use v3 cron which respects standard cron spec

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/micro/micro/v3 v3.0.0-beta.7.0.20201028201939-a2d86fdeb9d7
 	github.com/minio/minio-go/v7 v7.0.5
 	github.com/patrickmn/go-cache v2.1.0+incompatible
-	github.com/robfig/cron v1.2.0
+	github.com/robfig/cron/v3 v3.0.1
 	github.com/scaleway/scaleway-sdk-go v1.0.0-beta.6
 	github.com/sethvargo/go-diceware v0.2.0
 	github.com/slack-go/slack v0.6.5

--- a/go.sum
+++ b/go.sum
@@ -433,8 +433,8 @@ github.com/rainycape/memcache v0.0.0-20150622160815-1031fa0ce2f2/go.mod h1:7tZKc
 github.com/rcrowley/go-metrics v0.0.0-20181016184325-3113b8401b8a/go.mod h1:bCqnVzQkZxMG4s8nGwiZ5l3QUCyqpo9Y+/ZMZ9VjZe4=
 github.com/rhysd/go-github-selfupdate v1.2.2 h1:G+mNzkc1wEtpmM6sFS/Ghkeq+ad4Yp6EZEHyp//wGEo=
 github.com/rhysd/go-github-selfupdate v1.2.2/go.mod h1:khesvSyKcXDUxeySCedFh621iawCks0dS/QnHPcpCws=
-github.com/robfig/cron v1.2.0 h1:ZjScXvvxeQ63Dbyxy76Fj3AT3Ut0aKsyd2/tl3DTMuQ=
-github.com/robfig/cron v1.2.0/go.mod h1:JGuDeoQd7Z6yL4zQhZ3OPEVHB7fL6Ka6skscFHfmt2k=
+github.com/robfig/cron/v3 v3.0.1 h1:WdRxkvbJztn8LMz/QEvLN5sBU+xKpSqwwUO1Pjr4qDs=
+github.com/robfig/cron/v3 v3.0.1/go.mod h1:eQICP3HwyT7UooqI/z+Ov+PtYAWygg1TEWWzGIFLtro=
 github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af/go.mod h1:XWv6SoW27p1b0cqNHllgS5HIMJraePCO15w5zCzIWYg=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
 github.com/rs/cors v1.7.0 h1:+88SsELBHx5r+hZ8TCkggzSstaWNbDvThkVK8H6f9ik=

--- a/infrastructure/check.go
+++ b/infrastructure/check.go
@@ -32,7 +32,7 @@ func checkInfraUsageCron() {
 	for _, i := range issues {
 		msg += fmt.Sprintf("\n- %v", i)
 	}
-	slackbot.SendMessage("team-important",
+	slackbot.SendMessage("alerts",
 		slack.MsgOptionUsername("Infrastructure Service"),
 		slack.MsgOptionText(msg, false),
 	)

--- a/infrastructure/main.go
+++ b/infrastructure/main.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"github.com/robfig/cron"
+	"github.com/robfig/cron/v3"
 	"github.com/slack-go/slack"
 
 	"github.com/minio/minio-go/v7"


### PR DESCRIPTION
Infra check was firing at 9minutes past the hour rather than at 9am because cron was using non standard spec which began with seconds field. Upgrade to v3 respects standard cron spec.