### PR TITLE
accounts should be admin at signup

### DIFF
--- a/signup/handler/signup.go
+++ b/signup/handler/signup.go
@@ -416,7 +416,7 @@ func (s *Signup) completeSignup(ctx context.Context, req *signup.CompleteSignupR
 	if len(req.Secret) == 0 {
 		secret = uuid.New().String()
 	}
-	_, err = s.auth.Generate(tok.CustomerID, auth.WithSecret(secret), auth.WithIssuer(ns), auth.WithName(req.Email))
+	_, err = s.auth.Generate(tok.CustomerID, auth.WithSecret(secret), auth.WithIssuer(ns), auth.WithName(req.Email), auth.WithScopes("admin"))
 	if err != nil {
 		logger.Errorf("Error generating token for %v: %v", tok.CustomerID, err)
 		return merrors.InternalServerError("signup.CompleteSignup", errInternal)


### PR DESCRIPTION
With new lockdown of micro server, accounts need to have admin scope to be able to run services in their namespace