### PR TITLE
Specify consumer group

### DIFF
--- a/balance/handler/events.go
+++ b/balance/handler/events.go
@@ -21,7 +21,8 @@ func (b *Balance) consumeEvents() {
 			var err error
 			evs, err = mevents.Consume(topic,
 				mevents.WithAutoAck(false, 30*time.Second),
-				mevents.WithRetryLimit(10)) // 10 retries * 30 secs ackWait gives us 5 mins of tolerance for issues
+				mevents.WithRetryLimit(10),
+				mevents.WithGroup("balance")) // 10 retries * 30 secs ackWait gives us 5 mins of tolerance for issues
 			if err == nil {
 				handler(evs)
 				start = time.Now()

--- a/customers/handler/events.go
+++ b/customers/handler/events.go
@@ -54,7 +54,8 @@ func (c *Customers) consumeEvents() {
 			var err error
 			evs, err = mevents.Consume(topic,
 				mevents.WithAutoAck(false, 30*time.Second),
-				mevents.WithRetryLimit(10)) // 10 retries * 30 secs ackWait gives us 5 mins of tolerance for issues
+				mevents.WithRetryLimit(10),
+				mevents.WithGroup("customers")) // 10 retries * 30 secs ackWait gives us 5 mins of tolerance for issues
 			if err == nil {
 				handler(evs)
 				start = time.Now()

--- a/publicapiusage/handler/events.go
+++ b/publicapiusage/handler/events.go
@@ -17,7 +17,8 @@ func (p *Publicapiusage) consumeEvents() {
 			var err error
 			evs, err = mevents.Consume(topic,
 				mevents.WithAutoAck(false, 30*time.Second),
-				mevents.WithRetryLimit(10)) // 10 retries * 30 secs ackWait gives us 5 mins of tolerance for issues
+				mevents.WithRetryLimit(10),
+				mevents.WithGroup("publicapiusage")) // 10 retries * 30 secs ackWait gives us 5 mins of tolerance for issues
 			if err == nil {
 				handler(evs)
 				start = time.Now()

--- a/publicapiusage/handler/events.go
+++ b/publicapiusage/handler/events.go
@@ -17,8 +17,8 @@ func (p *Publicapiusage) consumeEvents() {
 			var err error
 			evs, err = mevents.Consume(topic,
 				mevents.WithAutoAck(false, 30*time.Second),
-				mevents.WithRetryLimit(10),
-				mevents.WithGroup("publicapiusage")) // 10 retries * 30 secs ackWait gives us 5 mins of tolerance for issues
+				mevents.WithRetryLimit(10), // 10 retries * 30 secs ackWait gives us 5 mins of tolerance for issues
+				mevents.WithGroup("publicapiusage"))
 			if err == nil {
 				handler(evs)
 				start = time.Now()

--- a/signup/handler/events.go
+++ b/signup/handler/events.go
@@ -27,7 +27,8 @@ func (s *Signup) consumeEvents() {
 		var err error
 		evs, err = mevents.Consume(signupTopic,
 			mevents.WithAutoAck(false, 30*time.Second),
-			mevents.WithRetryLimit(10)) // 10 retries * 30 secs ackWait gives us 5 mins of tolerance for issues
+			mevents.WithRetryLimit(10),
+			mevents.WithGroup("signup")) // 10 retries * 30 secs ackWait gives us 5 mins of tolerance for issues
 		if err == nil {
 			s.processSignupEvents(evs)
 			start = time.Now()


### PR DESCRIPTION
Weren't specifying a consumer group so multiple instances were probably getting duplicates